### PR TITLE
optimize reset app's logic

### DIFF
--- a/automator.py
+++ b/automator.py
@@ -49,8 +49,10 @@ class Automator:
                 print("[%s] Train come."%time.asctime())
                 self.harvest(self.harvest_filter, good_id)
             else:
-                print("[%s] No Train."%time.asctime())
-                findSomething = True
+                print("[%s] No Goods! Wait 2s."%time.asctime())
+                self.swipe()
+                time.sleep(2)
+                continue
             
             # 再看看是不是有货没收，如果有就重启app
             good_id = self._has_good()
@@ -60,6 +62,7 @@ class Automator:
                 time.sleep(2)
                 # 重新启动app
                 self.d.app_start("com.tencent.jgm")
+                time.sleep(15)
                 continue
 
             # 简单粗暴的方式，处理 “XX之光” 的荣誉显示。


### PR DESCRIPTION
speed_up设为True后的一些小问题:
1、在判断货车到来的时候，货车来了而货物还没显示 会误判no train 然后会触发app重启 浪费一次货车 
2、reset app之后要过几秒钟货物才会来，这里加sleep可能会比较好；
3、reset app之后最好是sleep个10秒左右比较好，否则在app启动界面就会判断货物是否到来，一直打印no train；有时候还会判定有货物，造成误操作；